### PR TITLE
Feature/add support for multiple scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ schema model: Order do
   attribute(:billing_address) { '23 Wall Street, NY' }
 end
 ```
-- and run `bundle exec rake remont['db/remont.rb']`
+- and run `remont` rake task with the path to the processing script
+```bash
+bundle exec rake "remont[db/anonymize.rb]"
+```
 
-If you don't pass the script path to the rake task, the default path will be `db/remont.rb`. 
+Passing the script path to the rake task is mandatory.
 Running the rake task would result in updating `email` (and `anonymized_at`) column for each row in the `users` table, and `billing_address` column for each row in the `orders` table.
 
 ### Schema

--- a/README.md
+++ b/README.md
@@ -21,14 +21,12 @@ Add `config/initializers/remont.rb`
 ```ruby
 Remont.setup do |config|
   config.process_timestamp_attribute = :processed_at
-  config.script_path = 'db/remont.rb'
 end
 ```
 
 | Option                        | Default value    | Description                                |
 | ---                           | :---:            | ---                                        |
 | `process_timestamp_attribute` | `:processed_at`  | processing status attribute identifier     |
-| `script_path`                 | `'db/remont.rb'` | entry point for the schema processing task |
 
 On successful record processing, `process_timestamp_attribute` on the record will be set to the current processing time (`Time.now.getlocal`).
 
@@ -38,11 +36,10 @@ In the following example, the intention is to simulate anonymization of the `use
 ```ruby
 # config/initializers/remont.rb
 Remont.setup do |config|
-  config.process_timestamp_attribute = :anonyzmied_at
-  config.script_path = 'db/anonymize.rb'
+  config.process_timestamp_attribute = :anonymized_at
 end
 ```
-- define processing script
+- define the processing script
 ```ruby
 # db/anonymize.rb
 schema model: User  do
@@ -53,8 +50,9 @@ schema model: Order do
   attribute(:billing_address) { '23 Wall Street, NY' }
 end
 ```
-- and run `bundle exec rake remont`
+- and run `bundle exec rake remont['db/remont.rb']`
 
+If you don't pass the script path to the rake task, the default path will be `db/remont.rb`. 
 Running the rake task would result in updating `email` (and `anonymized_at`) column for each row in the `users` table, and `billing_address` column for each row in the `orders` table.
 
 ### Schema

--- a/lib/remont/config.rb
+++ b/lib/remont/config.rb
@@ -6,7 +6,7 @@ module Remont
     attr_accessor :process_timestamp_attribute
 
     # @return [String]
-    attr_accessor :script_path
+    attr_reader :script_path
 
     def initialize
       @process_timestamp_attribute = :processed_at

--- a/lib/remont/config.rb
+++ b/lib/remont/config.rb
@@ -1,16 +1,10 @@
 module Remont
   class Config
-    DEFAULT_SCRIPT_PATH = 'db/remont.rb'.freeze
-
     # @return [Symbol]
     attr_accessor :process_timestamp_attribute
 
-    # @return [String]
-    attr_reader :script_path
-
     def initialize
       @process_timestamp_attribute = :processed_at
-      @script_path = DEFAULT_SCRIPT_PATH
     end
   end
 end

--- a/lib/remont/tasks/remont.rake
+++ b/lib/remont/tasks/remont.rake
@@ -1,5 +1,6 @@
 desc 'Run schema processing'
-task remont: :environment do
-  path = Rails.root.join(Remont.config.script_path)
+task remont, [:script_path] => :environment do |_, args|
+  script_path = args[:script_path] || Remont.config.script_path
+  path = Rails.root.join(script_path)
   Remont::Script.new(path).run!
 end

--- a/lib/remont/tasks/remont.rake
+++ b/lib/remont/tasks/remont.rake
@@ -1,6 +1,8 @@
 desc 'Run schema processing'
-task remont, [:script_path] => :environment do |_, args|
-  script_path = args[:script_path] || Remont.config.script_path
+task :remont, [:script_path] => :environment do |_, args|
+  script_path = args[:script_path]
+  abort 'Missing script path' unless script_path
+
   path = Rails.root.join(script_path)
   Remont::Script.new(path).run!
 end

--- a/spec/lib/remont/config_spec.rb
+++ b/spec/lib/remont/config_spec.rb
@@ -5,9 +5,5 @@ RSpec.describe Remont::Config do
     it 'initializes default process timestamp attribute' do
       expect(config.process_timestamp_attribute).to eq(:processed_at)
     end
-
-    it 'initializes default script path' do
-      expect(config.script_path).to eq(Remont::Config::DEFAULT_SCRIPT_PATH)
-    end
   end
 end


### PR DESCRIPTION
Removed the option of defining the script path through the initializer so it could be passed to the rake task instead.
Also, made the attribute `name` available to processors as this could be useful.
Updated documentation and tests.