### PR TITLE
Add support for configuring processing status attribute per schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ end
 
 | Option                        | Default value    | Description                                |
 | ---                           | :---:            | ---                                        |
-| `process_timestamp_attribute` | `:processed_at`  | processing status attribute identifier     |
+| `process_timestamp_attribute` | `nil`            | processing status attribute identifier     |
 | `script_path`                 | `'db/remont.rb'` | entry point for the schema processing task |
 
 On successful record processing, `process_timestamp_attribute` on the record will be set to the current processing time (`Time.now.getlocal`).

--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ schema model: Order do
   scope { |scope| scope.where(status: :active) }
 end
 ```
-### Configuring the processing time attribute
-When `process_timestamp_attribute` is declared, the processing end time will be recorded for each processed record. Attribute can be configured globally (for all schema's), or individually per schema.
+### Recording the processing end time
+Library supports an option to store the processing end time of a record. Enable the behavior by configuring a processing status attribute identifier for the schema. Configure the attribute identifier
+- globally (`Remont::Config#process_timestamp_attribute`, for all schema's)
+- or individually per schema (in the schema DSL, overrides the global setting)
 ```ruby
 schema model: User, process_timestamp_attribute: :anonymized_at do
 end
@@ -87,14 +89,17 @@ schema model: Order do
   with_process_timestamp_attribute :anonymized_at
 end
 ```
+
+Set process status attribute to `nil` to disable the behavior. `nil`.
 ### Skipping the processed records
-In some cases, it's desirable to skip already processed records. You can opt-in to this behavior by declaring `without_processed` within the `schema` block. When declared, the processing dataset query will be extended with a condition that excludes already processed records (ie. `where(Remont.process_timestamp_attribute => nil)`)
+In some cases, it's desirable to skip already processed records. You can enable this behavior by declaring `without_processed` within the `schema` block. When declared, the processing dataset query will be extended with a condition that excludes already processed records.
 ```ruby
 schema model: User do
   without_processed
   # ...
 end
 ```
+Configure processing status attribute before declaring the `without_processed`. An error will be raised otherwise.
 ### Callbacks
 Custom pre-processing or post-processing behavior can be declared using `before` and `after` callbacks.
 ```ruby

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ schema model: Order do
   scope { |scope| scope.where(status: :active) }
 end
 ```
+### Configuring the processing time attribute
+When `process_timestamp_attribute` is declared, the processing end time will be recorded for each processed record. Attribute can be configured globally (for all schema's), or individually per schema.
+```ruby
+schema model: User, process_timestamp_attribute: :anonymized_at do
+end
+
+schema model: Order do
+  with_process_timestamp_attribute :anonymized_at
+end
+```
 ### Skipping the processed records
 In some cases, it's desirable to skip already processed records. You can opt-in to this behavior by declaring `without_processed` within the `schema` block. When declared, the processing dataset query will be extended with a condition that excludes already processed records (ie. `where(Remont.process_timestamp_attribute => nil)`)
 ```ruby

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ end
 ```
 ### Recording the processing end time
 Library supports an option to store the processing end time of a record. Enable the behavior by configuring a processing status attribute identifier for the schema. Configure the attribute identifier
-- globally (`Remont::Config#process_timestamp_attribute`, for all schema's)
+- globally (`Remont::Config#process_timestamp_attribute`, for all schemas)
 - or individually per schema (in the schema DSL, overrides the global setting)
 ```ruby
 schema model: User, process_timestamp_attribute: :anonymized_at do
@@ -90,7 +90,7 @@ schema model: Order do
 end
 ```
 
-Set process status attribute to `nil` to disable the behavior. `nil`.
+Set process status attribute to `nil` to disable the behavior.
 ### Skipping the processed records
 In some cases, it's desirable to skip already processed records. You can enable this behavior by declaring `without_processed` within the `schema` block. When declared, the processing dataset query will be extended with a condition that excludes already processed records.
 ```ruby

--- a/lib/remont/config.rb
+++ b/lib/remont/config.rb
@@ -9,7 +9,7 @@ module Remont
     attr_accessor :script_path
 
     def initialize
-      @process_timestamp_attribute = :processed_at
+      @process_timestamp_attribute = nil
       @script_path = DEFAULT_SCRIPT_PATH
     end
   end

--- a/lib/remont/record_processor.rb
+++ b/lib/remont/record_processor.rb
@@ -2,11 +2,11 @@ module Remont
   class RecordProcessor
     NOOP = proc {}
 
-    # @param [Array<Remont::Attribute>] attributes
+    # @param [Remont::Schema] schema
     # @param [Proc] before
     # @param [Proc] after
-    def initialize(attributes, before, after)
-      @attributes = attributes
+    def initialize(schema, before, after)
+      @schema = schema
       @before = before || NOOP
       @after = after || NOOP
     end
@@ -25,12 +25,13 @@ module Remont
 
     private
 
-    attr_reader :attributes
+    attr_reader :schema
     attr_reader :before
     attr_reader :after
 
     def processed_attributes(record)
-      attributes
+      schema
+        .attributes
         .select { |attribute| record.send(attribute.name).present? }
         .reduce(default_processed_attributes) do |memo, attribute|
           memo.merge(attribute.name => attribute.process(record.send(attribute.name), record))
@@ -38,10 +39,10 @@ module Remont
     end
 
     def default_processed_attributes
-      return {} unless Remont.config.process_timestamp_attribute
+      return {} unless schema.process_timestamp_attribute
 
       {
-        Remont.config.process_timestamp_attribute => Time.now.getlocal
+        schema.process_timestamp_attribute => Time.now.getlocal
       }
     end
   end

--- a/lib/remont/schema.rb
+++ b/lib/remont/schema.rb
@@ -1,5 +1,7 @@
 module Remont
   class Schema
+    MISSING_PROCESSING_STATUS_ATTR = "Processing status attribute isn't configured".freeze
+
     # @return [Array<Remont::Attribute>]
     attr_reader :attributes
 
@@ -25,6 +27,8 @@ module Remont
 
     # @return [Remont::Schema]
     def without_processed
+      raise MISSING_PROCESSING_STATUS_ATTR if @process_timestamp_attribute.nil?
+
       @without_processed_scope = proc { |scope| scope.where(process_timestamp_attribute => nil) }
 
       self

--- a/lib/remont/schema.rb
+++ b/lib/remont/schema.rb
@@ -1,16 +1,21 @@
 module Remont
   class Schema
-    DEFAULT_SCOPE = proc { |scope| scope }
-    WITHOUT_PROCESSED = proc { |scope| scope.where(Remont.config.process_timestamp_attribute => nil) }
+    # @return [Array<Remont::Attribute>]
+    attr_reader :attributes
+
+    # @return [Nil, String, Symbol]
+    attr_reader :process_timestamp_attribute
 
     # @param [Hash] opts
     # @option [Class] :model
     # @option [Proc] :scope
+    # @option [String, Symbol] :process_timestamp_attribute
     # @param [Proc] block
     def initialize(opts = {}, &block)
       @model = opts.fetch(:model)
-      @model_scope = opts.fetch(:scope, DEFAULT_SCOPE)
-      @without_processed_scope = DEFAULT_SCOPE
+      @model_scope = opts.fetch(:scope, default_scope)
+      @without_processed_scope = default_scope
+      @process_timestamp_attribute = opts.fetch(:process_timestamp_attribute, Remont.config.process_timestamp_attribute)
       @before_cb = nil
       @after_cb = nil
       @attributes = []
@@ -20,7 +25,15 @@ module Remont
 
     # @return [Remont::Schema]
     def without_processed
-      @without_processed_scope = WITHOUT_PROCESSED
+      @without_processed_scope = proc { |scope| scope.where(process_timestamp_attribute => nil) }
+
+      self
+    end
+
+    # @param [String, Symbol] attr_name
+    # @return [Remont::Schema]
+    def with_process_timestamp_attribute(attr_name)
+      @process_timestamp_attribute = attr_name
 
       self
     end
@@ -70,18 +83,21 @@ module Remont
     attr_reader :model
     attr_reader :without_processed_scope
     attr_reader :model_scope
-    attr_reader :attributes
     attr_reader :before_cb
     attr_reader :after_cb
 
     def processor
-      @processor ||= RecordProcessor.new(attributes, before_cb, after_cb)
+      @processor ||= RecordProcessor.new(self, before_cb, after_cb)
     end
 
     def records_for_processing
       model_scope.call(
         without_processed_scope.call(model.all)
       )
+    end
+
+    def default_scope
+      proc { |scope| scope }
     end
   end
 end

--- a/lib/remont/tasks/remont.rake
+++ b/lib/remont/tasks/remont.rake
@@ -1,5 +1,5 @@
 desc 'Run schema processing'
-task remont: :remonte_env do
+task remont: :remont_env do
   path = Rails.root.join(Remont.config.script_path)
   Remont::Script.new(path).run!
 end

--- a/lib/remont/tasks/remont.rake
+++ b/lib/remont/tasks/remont.rake
@@ -1,5 +1,10 @@
 desc 'Run schema processing'
-task remont: :environment do
+task remont: :remonte_env do
   path = Rails.root.join(Remont.config.script_path)
   Remont::Script.new(path).run!
+end
+
+task :remont_env do # rubocop:disable Rails/RakeEnvironment
+  Rake::Task['environment'].invoke
+rescue StandardError # rubocop:disable Lint/SuppressedException
 end

--- a/spec/lib/remont/config_spec.rb
+++ b/spec/lib/remont/config_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Remont::Config do
     let(:config) { described_class.new }
 
     it 'initializes default process timestamp attribute' do
-      expect(config.process_timestamp_attribute).to eq(:processed_at)
+      expect(config.process_timestamp_attribute).to be_nil
     end
 
     it 'initializes default script path' do

--- a/spec/lib/remont/record_processor_spec.rb
+++ b/spec/lib/remont/record_processor_spec.rb
@@ -1,13 +1,15 @@
 RSpec.describe Remont::RecordProcessor do
   subject(:processor) do
-    described_class.new(
-      [Remont::Attribute.new(:email) { 'email' },
-       Remont::Attribute.new(:role) { 'role' }],
-      callback,
-      callback
-    )
+    described_class.new(schema, callback, callback)
   end
 
+  let(:schema) do
+    Remont::Schema.new(model: User) do
+      with_process_timestamp_attribute :anonymized_at
+      attribute(:email) { 'email' }
+      attribute(:role) { 'role' }
+    end
+  end
   let(:callback) { instance_double('Proc', call: nil) }
   let(:record) do
     instance_double('User', email: 'bob@example.com', role: 'admin', update_columns: nil)
@@ -20,7 +22,7 @@ RSpec.describe Remont::RecordProcessor do
     end
 
     expect(record).to have_received(:update_columns).with(
-      email: 'email', role: 'role', processed_at: now
+      email: 'email', role: 'role', anonymized_at: now
     )
   end
 

--- a/spec/lib/remont/schema_spec.rb
+++ b/spec/lib/remont/schema_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Remont::Schema do
   it 'processes each matching record' do # rubocop:disable RSpec/ExampleLength
     bob = User.create(email: 'bob@example.com', role: 'admin', processed_at: nil)
-    schema = described_class.new(model: User) do
+    schema = described_class.new(model: User, process_timestamp_attribute: :processed_at) do
       attribute(:email) { 'email' }
     end
 
@@ -16,10 +16,10 @@ RSpec.describe Remont::Schema do
   end
 
   context 'when default process timestamp attribute is overriden' do
-    let!(:bob) { User.create(email: 'bob@example.com', role: 'admin', anonymized_at: nil) }
+    let!(:bob) { User.create(email: 'bob@example.com', role: 'admin', processed_at: nil) }
 
     it 'uses new process timestamp attribute from schema arguments' do
-      schema = described_class.new(model: User, process_timestamp_attribute: :anonymized_at) do
+      schema = described_class.new(model: User, process_timestamp_attribute: :processed_at) do
         attribute(:email) { 'email' }
       end
 
@@ -28,12 +28,12 @@ RSpec.describe Remont::Schema do
         schema.process!
       end
 
-      expect(bob.reload.anonymized_at).to be_within(1).of(now)
+      expect(bob.reload.processed_at).to be_within(1).of(now)
     end
 
     it 'uses new process timestamp attribute from schema definition' do
       schema = described_class.new(model: User) do
-        with_process_timestamp_attribute :anonymized_at
+        with_process_timestamp_attribute :processed_at
         attribute(:email) { 'email' }
       end
 
@@ -42,13 +42,13 @@ RSpec.describe Remont::Schema do
         schema.process!
       end
 
-      expect(bob.reload.anonymized_at).to be_within(1).of(now)
+      expect(bob.reload.processed_at).to be_within(1).of(now)
     end
   end
 
   context 'without scope applied' do
     let(:schema) do
-      described_class.new(model: User) do
+      described_class.new(model: User, process_timestamp_attribute: :processed_at) do
         attribute(:email) { 'email' }
       end
     end
@@ -68,7 +68,8 @@ RSpec.describe Remont::Schema do
     let(:schema) do
       described_class.new(
         model: User,
-        scope: proc { |relation| relation.where(role: 'customer') }
+        scope: proc { |relation| relation.where(role: 'customer') },
+        process_timestamp_attribute: :processed_at
       ) do
         attribute(:email) { 'email' }
       end
@@ -87,7 +88,7 @@ RSpec.describe Remont::Schema do
 
   context 'when skip process scope is enabled' do
     let(:schema) do
-      described_class.new(model: User) do
+      described_class.new(model: User, process_timestamp_attribute: :processed_at) do
         without_processed
         attribute(:email) { 'email' }
       end
@@ -112,7 +113,7 @@ RSpec.describe Remont::Schema do
     let(:schema) do
       cb = callback
 
-      described_class.new(model: User) do
+      described_class.new(model: User, process_timestamp_attribute: :processed_at) do
         without_processed
         attribute(:email) { 'email' }
         before { |*args| cb.call(*args) }
@@ -136,7 +137,7 @@ RSpec.describe Remont::Schema do
     let(:schema) do
       cb = callback
 
-      described_class.new(model: User) do
+      described_class.new(model: User, process_timestamp_attribute: :processed_at) do
         without_processed
         attribute(:email) { 'email' }
         after { |*args| cb.call(*args) }

--- a/spec/lib/remont/schema_spec.rb
+++ b/spec/lib/remont/schema_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe Remont::Schema do
     expect(bob.processed_at).to be_within(1).of(now)
   end
 
-  context 'when default process timestamp attribute is overriden' do
+  context 'when default process status attribute is overriden' do
     let!(:bob) { User.create(email: 'bob@example.com', role: 'admin', processed_at: nil) }
 
-    it 'uses new process timestamp attribute from schema arguments' do
+    it 'uses new process status attribute from schema arguments' do
       schema = described_class.new(model: User, process_timestamp_attribute: :processed_at) do
         attribute(:email) { 'email' }
       end
@@ -31,7 +31,7 @@ RSpec.describe Remont::Schema do
       expect(bob.reload.processed_at).to be_within(1).of(now)
     end
 
-    it 'uses new process timestamp attribute from schema definition' do
+    it 'uses new process status attribute from schema definition' do
       schema = described_class.new(model: User) do
         with_process_timestamp_attribute :processed_at
         attribute(:email) { 'email' }
@@ -104,6 +104,14 @@ RSpec.describe Remont::Schema do
       bob.reload
       expect(bob.reload.processed_at).to be_within(1).of(last_processing_at)
       expect(alice.reload.processed_at).not_to be_nil
+    end
+
+    it "fails if process status attribute isn't configured" do
+      expect do
+        described_class.new(model: User, process_timestamp_attribute: nil) do
+          without_processed
+        end
+      end.to raise_error(Remont::Schema::MISSING_PROCESSING_STATUS_ATTR)
     end
   end
 

--- a/spec/lib/remont/schema_spec.rb
+++ b/spec/lib/remont/schema_spec.rb
@@ -15,6 +15,37 @@ RSpec.describe Remont::Schema do
     expect(bob.processed_at).to be_within(1).of(now)
   end
 
+  context 'when default process timestamp attribute is overriden' do
+    let!(:bob) { User.create(email: 'bob@example.com', role: 'admin', anonymized_at: nil) }
+
+    it 'uses new process timestamp attribute from schema arguments' do
+      schema = described_class.new(model: User, process_timestamp_attribute: :anonymized_at) do
+        attribute(:email) { 'email' }
+      end
+
+      now = Time.now.getlocal
+      Timecop.freeze(now) do
+        schema.process!
+      end
+
+      expect(bob.reload.anonymized_at).to be_within(1).of(now)
+    end
+
+    it 'uses new process timestamp attribute from schema definition' do
+      schema = described_class.new(model: User) do
+        with_process_timestamp_attribute :anonymized_at
+        attribute(:email) { 'email' }
+      end
+
+      now = Time.now.getlocal
+      Timecop.freeze(now) do
+        schema.process!
+      end
+
+      expect(bob.reload.anonymized_at).to be_within(1).of(now)
+    end
+  end
+
   context 'without scope applied' do
     let(:schema) do
       described_class.new(model: User) do

--- a/spec/lib/remont/script_spec.rb
+++ b/spec/lib/remont/script_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Remont::Script do
+  include TestHelpers::Script
+
+  it 'processes the records in the defined schema' do
+    bob = User.create(email: 'bob@example.com', role: 'admin', processed_at: nil)
+
+    process(<<~SCRIPT)
+      schema model: User do
+        attribute(:email) { '--' }
+      end
+    SCRIPT
+
+    bob.reload
+    expect(bob.email).to eq('--')
+    expect(bob.processed_at).not_to be_nil
+  end
+end

--- a/spec/lib/remont/script_spec.rb
+++ b/spec/lib/remont/script_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Remont::Script do
       end
     SCRIPT
 
-    bob.reload
-    expect(bob.email).to eq('--')
+    expect(bob.reload.email).to eq('--')
   end
 end

--- a/spec/lib/remont/script_spec.rb
+++ b/spec/lib/remont/script_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Remont::Script do
   include TestHelpers::Script
 
   it 'processes the records in the defined schema' do
-    bob = User.create(email: 'bob@example.com', role: 'admin', processed_at: nil)
+    bob = User.create(email: 'bob@example.com', role: 'admin')
 
     process(<<~SCRIPT)
       schema model: User do
@@ -12,6 +12,5 @@ RSpec.describe Remont::Script do
 
     bob.reload
     expect(bob.email).to eq('--')
-    expect(bob.processed_at).not_to be_nil
   end
 end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -11,7 +11,6 @@ ActiveRecord::Schema.define do
     t.string :email
     t.string :role
     t.datetime :processed_at
-    t.datetime :anonymized_at
   end
 end
 
@@ -25,10 +24,6 @@ class User < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord
   end
 
   def processed_at # rubocop:disable Lint/UselessMethodDefinition
-    super
-  end
-
-  def anonymized_at # rubocop:disable Lint/UselessMethodDefinition
     super
   end
 end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -11,6 +11,7 @@ ActiveRecord::Schema.define do
     t.string :email
     t.string :role
     t.datetime :processed_at
+    t.datetime :anonymized_at
   end
 end
 
@@ -24,6 +25,10 @@ class User < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord
   end
 
   def processed_at # rubocop:disable Lint/UselessMethodDefinition
+    super
+  end
+
+  def anonymized_at # rubocop:disable Lint/UselessMethodDefinition
     super
   end
 end

--- a/spec/support/test_helpers/script.rb
+++ b/spec/support/test_helpers/script.rb
@@ -1,0 +1,21 @@
+require 'tempfile'
+
+module TestHelpers
+  module Script
+    BASENAME = 'remont'.freeze
+    EXT = 'rake'.freeze
+
+    # @param [String] script
+    # @return [Object]
+    def process(script)
+      file = Tempfile.new([BASENAME, EXT])
+      file.write(script)
+      file.rewind
+
+      Remont::Script.new(file.path).run!
+    ensure
+      file.close
+      file.unlink
+    end
+  end
+end


### PR DESCRIPTION
### Aim
Add support for configuring processing status attribute per schema. It can be done through global config or through schema DSL.

### Solution
- add the ability to configure processing status attribute per schema
- raise an error when processing status isn't defined but `without_processed` is declared
- add `Remont::Script` specs
- update README to reflect changes